### PR TITLE
rbuildignore - dot to escaped dot

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,4 +12,4 @@ TODO\.md
 ^Jenkinsfile$
 ^\.lintr$
 ^data-raw$
-^staged_dependencies.yaml$
+^staged_dependencies\.yaml$


### PR DESCRIPTION
Update .Rbuildignore for ^stage_dependencies\\.yaml$.

Dot was not escaped