### PR TITLE
DelayedMatrix assays now get converted to matrix/array

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,7 @@ Imports:
     utils,
     utils.nest (>= 0.2.11)
 Suggests:
+    DelayedArray,
     DT,
     grid,
     httr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 * New `rename` method that makes renaming columns of `rowData` and `colData` as well as assay names in existing `SummarizedExperiment` objects much easier, as a step before converting to `HermesData`.
 * New `lapply` method that allows user to apply a function on all experiments in a `MultiAssayExperiment`.
 * New `isEmpty` method that checks whether a `SummarizedExperiment` object is empty.
-* When providing `DelayedMatrix` objects as assays, these are silently converted to `matrix`/`array`.
+* When providing `SummarizedExperiment` objects containing `DelayedMatrix` assays to the `HermesData()` constructor, these are silently converted to `matrix` assays to ensure downstream functionality.
 
 ### Bug Fixes
 * `normalize()` now also works when the `hermes` package is not loaded, i.e. you can use it with `hermes::normalize()`.

--- a/R/HermesData-class.R
+++ b/R/HermesData-class.R
@@ -107,13 +107,11 @@ HermesData <- function(object) { # nolint
   )
 
   assays(object) <- lapply(assays(object), function(x) {
-    if ("DelayedMatrix" %in% class(x)) {
+    if (is(x, "DelayedMatrix")) {
       x <- as.matrix(x)
       mode(x) <- "integer"
-      x
-    } else {
-      x
     }
+    x
   })
 
   missing_row <- setdiff(.row_data_cols, names(rowData(object)))

--- a/tests/testthat/test-HermesData-class.R
+++ b/tests/testthat/test-HermesData-class.R
@@ -91,24 +91,16 @@ test_that("HermesData creates missing columns with NAs correctly", {
   expect_true(all(.row_data_cols %in% names(rowData(result))))
 })
 
-test_that("HermesData converts DelayedMatrix assays to matrix/assay type", {
-  n_row <- length(rownames(SummarizedExperiment::rowData(hermes_data)))
-  n_col <- length(colnames(SummarizedExperiment::assay(hermes_data)))
-  vals <- rnorm(n = n_row * n_col, mean = 10, sd = 20)
-  vals_m <- round(matrix(vals, ncol = n_col))
-  vals_m <- abs(vals_m)
-  rownames(vals_m) <- rownames(SummarizedExperiment::rowData(hermes_data))
-  colnames(vals_m) <- rownames(SummarizedExperiment::colData(hermes_data))
-  mock_delayed_array <- DelayedArray::DelayedArray(vals_m)
-  my_se <- SummarizedExperiment(
-    rowData = SummarizedExperiment::rowData(hermes_data),
-    colData = SummarizedExperiment::colData(hermes_data)
-  )
-  SummarizedExperiment::assays(my_se) <- SimpleList(mock_delayed_array, mock_delayed_array)
-  SummarizedExperiment::assayNames(my_se) <- c("counts", "not_counts")
-  my_hd <- HermesData(my_se)
-
-  expect_true(all(unlist(lapply(assays(my_hd), function(x) c("matrix", "array") %in% class(x)))))
+test_that("HermesData converts DelayedMatrix assays correctly to matrix assays", {
+  se <- summarized_experiment
+  assay(se, "delayed") <- DelayedArray::DelayedArray(assay(se, "counts"))
+  expect_s4_class(assay(se, "delayed"), "DelayedMatrix")
+  result <- HermesData(se)
+  expect_matrix(assay(result, "delayed"))
+  a1 <- assay(se, "delayed")
+  a2 <- assay(result, "delayed")
+  expect_identical(dim(a1), dim(a2))
+  expect_identical(as.integer(a1), as.integer(a2))
 })
 
 test_that("RangedHermesData objects can be created with constructor HermesData", {


### PR DESCRIPTION
closes #68 

As discussed in the issue, we decided not to preemptively implement hdf5 compatibility since new methods would have to be implemented for some of the involved packages (`edgeR`, `limma`, ...). Therefore, `HermesData` now simply loads the data into RAM, converts it to a `matrix` and proceeds as normal.

Might cause performance issues down the road with gigantic and/or sparse data. 