### PR TITLE
149: add version requirement for `ggrepel` so we have `max.overlaps`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ Imports:
     forcats,
     GenomicRanges,
     ggplot2,
-    ggrepel,
+    ggrepel (>= 0.9),
     IRanges,
     lifecycle,
     limma,


### PR DESCRIPTION
progresses #149

Cf. https://cran.r-project.org/web/packages/ggrepel/news/news.html where `max.overlaps` is introduced.